### PR TITLE
Return to typewriter mode suggestion

### DIFF
--- a/Game/Levels/Addition/L01zero_add.lean
+++ b/Game/Levels/Addition/L01zero_add.lean
@@ -29,8 +29,8 @@ will ask us to show that if `0 + d = d` then `0 + succ d = succ d`. Because
 
 See if you can do your first induction proof in Lean.
 
-By the way, if you are still in the editor mode from the last world, you can swap
-back to typewriter mode by clicking the `>_` button.
+(By the way, if you are still in the \"Editor mode\" from the last world, you can swap
+back to \"Typewriter mode\" by clicking the `>_` button in the top right.)
 "
 
 /--

--- a/Game/Levels/Addition/L01zero_add.lean
+++ b/Game/Levels/Addition/L01zero_add.lean
@@ -28,6 +28,9 @@ will ask us to show that if `0 + d = d` then `0 + succ d = succ d`. Because
 `0` and successor are the only way to make numbers, this will cover all the cases.
 
 See if you can do your first induction proof in Lean.
+
+By the way, if you are still in the editor mode from the last world, you can swap
+back to typewriter mode by clicking the `>_` button.
 "
 
 /--

--- a/Game/Levels/Tutorial/L08twoaddtwo.lean
+++ b/Game/Levels/Tutorial/L08twoaddtwo.lean
@@ -51,7 +51,7 @@ written as several lines of code. Move your cursor between lines to see
 the goal state at any point. Now cut and paste your code elsewhere if you
 want to save it, and paste the above proof in instead. Move your cursor
 around to investigate. When you've finished, click the `>_` button in the top right to
-move back into command line mode.
+move back into \"Typewriter mode\".
 
 You have finished tutorial world!
 Click \"Leave World\" to go back to the


### PR DESCRIPTION
I was assigned to play through the game by my professor. When I got to the end of the tutorial world, I left the game in the editor mode, and was confused when I opened up the next world. I believe it would be helpful to add a note in the intro of the first level in the addition world reminding users to switch back to the typewriter mode. My professor also added a change to use consistent language for referencing the typewriter mode. 