### PR TITLE
alternate proof for `add_right_eq_self`

### DIFF
--- a/Game/Levels/AdvAddition/L04add_right_eq_self.lean
+++ b/Game/Levels/AdvAddition/L04add_right_eq_self.lean
@@ -48,19 +48,17 @@ rw [add_comm]
 exact add_left_eq_self y x
 ```
 
-Alternatively you can just prove it by induction on `x`
-(the dots in the proof just indicate the two goals and
-can be omitted):
+Alternatively you can just prove it by induction on `x`:
 
 ```
-  induction x with d hd
-  · intro h
-    rw [zero_add] at h
-    assumption
-  · intro h
-    rw [succ_add] at h
-    apply succ_inj at h
-    apply hd at h
-    assumption
+induction x with d hd
+intro h
+rw [zero_add] at h
+exact h
+intro h
+rw [succ_add] at h
+apply succ_inj at h
+apply hd at h
+exact h
 ```
 "


### PR DESCRIPTION
The second proof proposed for `add_right_eq_self` does not work because the `assumption` tactic is not available (and has not been introduced in the text). Also the dots seem to cause problems... Here is an alternate proof that works and which is written in the same style as in the rest of the game (no dots for subgoals, use `exact` rather than `assumption`). 