### PR TITLE
upgrade to actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         run: zip game.zip * .lake/ .i18n/ -r
 
       - name: upload compressed game folder
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-for-server-import
           path: |


### PR DESCRIPTION
I got an email from GitHub saying v3 will be deprecated in December, so I figured I'd do this for repos under leanprover-community before I forgot.