### PR TITLE
Fix terminology in L02rw.lean

### DIFF
--- a/Game/Levels/Tutorial/L02rw.lean
+++ b/Game/Levels/Tutorial/L02rw.lean
@@ -164,7 +164,7 @@ your list of assumptions. Lean thinks of `h` as being a secret proof of the
 assumption, rather like `x` is a secret number.
 
 Before we can use `rfl`, we have to \"substitute in for $y$\".
-We do this in Lean by *rewriting* the proof with `h`,
+We do this in Lean by *rewriting* the goal with `h`,
 using the `rw` tactic.
 "
 

--- a/Game/Levels/Tutorial/L02rw.lean
+++ b/Game/Levels/Tutorial/L02rw.lean
@@ -164,7 +164,7 @@ your list of assumptions. Lean thinks of `h` as being a secret proof of the
 assumption, rather like `x` is a secret number.
 
 Before we can use `rfl`, we have to \"substitute in for $y$\".
-We do this in Lean by *rewriting* the proof `h`,
+We do this in Lean by *rewriting* the assumption `h`,
 using the `rw` tactic.
 "
 

--- a/Game/Levels/Tutorial/L02rw.lean
+++ b/Game/Levels/Tutorial/L02rw.lean
@@ -164,7 +164,7 @@ your list of assumptions. Lean thinks of `h` as being a secret proof of the
 assumption, rather like `x` is a secret number.
 
 Before we can use `rfl`, we have to \"substitute in for $y$\".
-We do this in Lean by *rewriting* the assumption `h`,
+We do this in Lean by *rewriting* the proof with `h`,
 using the `rw` tactic.
 "
 


### PR DESCRIPTION
This pull request includes a small change to the `Game/Levels/Tutorial/L02rw.lean` file. ~~~The change clarifies the language by replacing "proof" with "assumption" in the context of rewriting with the `rw` tactic.~~~

UPDATE: In it's current version the PR suggests to replace :

```
We do this in Lean by *rewriting* the proof `h`,
```
with 
```
We do this in Lean by *rewriting* the goal with `h`,
```

Indeed, `h` is not the proof itself and the goal is what is being rewritten ([reference](https://lean-lang.org/theorem_proving_in_lean4//Tactics/#rewriting)).