### PR TITLE
Remove extra space, that prevent translation

### DIFF
--- a/Game/Levels/AdvMultiplication/L09mul_left_cancel.lean
+++ b/Game/Levels/AdvMultiplication/L09mul_left_cancel.lean
@@ -40,7 +40,7 @@ Statement mul_left_cancel (a b c : ℕ) (ha : a ≠ 0) (h : a * b = a * c) : b =
     · rw [h2]
       rfl
   · Hint "The inductive hypothesis `hd` is \"For all natural numbers `c`, `a * d = a * c → d = c`\".
-    You can `apply` it `at` any hypothesis of the form `a * d = a * ?`. "
+    You can `apply` it `at` any hypothesis of the form `a * d = a * ?`."
     Hint (hidden := true) "Split into cases `c = 0` and `c = succ e` with `cases c with e`."
     cases c with e
     · rw [mul_succ, mul_zero] at h


### PR DESCRIPTION
There is an extra space at the end of line 45. As a result, the English text no longer matches the one in the .i18n/en/Game.pot file, which prevents the translations from being displayed for this hint.