### PR TITLE
fix: remove dot notation on MyNat.succ

### DIFF
--- a/Game/MyNat/Definition.lean
+++ b/Game/MyNat/Definition.lean
@@ -6,6 +6,8 @@ inductive MyNat where
 | succ : MyNat → MyNat
 -- deriving BEq, DecidableEq, Inhabited
 
+attribute [pp_nodot] MyNat.succ
+
 @[inherit_doc]
 notation (name := MyNatNotation) (priority := 1000000) "ℕ" => MyNat
 -- Note: as long as we do not import `Mathlib.Init.Data.Nat.Notation` this is fine.


### PR DESCRIPTION
On [tutorial world, level 3](https://adam.math.hhu.de/#/g/leanprover-community/nng4/world/Tutorial/level/3), the goal displays as `2 = (succ 0).succ` rather than `2 = succ (succ 0)`. I don't know when this change occurred but looking at all the text in the game it seems to me that it's written all under the assumption that dot notation is disabled, e.g. in [addition world level 2](https://adam.math.hhu.de/#/g/leanprover-community/nng4/world/Addition/level/2) we claim in the text to be proving `(succ a) + b = succ (a + b)` but the goal currently displays as `a.succ + b = (a + b).succ`. 

This PR disables dot notation for `MyNat.succ` and now the text in the game agrees with the Lean output. 